### PR TITLE
Allow periods in repository name

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func isGithubRepo(path string) (githubRepo, bool) {
 	// Make sure we do not forget to star the Github mirrors of Go's subpackages
 	path = strings.Replace(path, "golang.org/x/", "github.com/golang/", -1)
 
-	re := regexp.MustCompile(`^github\.com\/[a-zA-Z\d-]+\/[a-zA-Z\d-]+`)
+	re := regexp.MustCompile(`^github\.com\/[a-zA-Z\d-]+\/[a-zA-Z\d-\.]+`)
 	repoPath := re.FindString(path)
 	if repoPath != "" {
 		parts := strings.Split(repoPath, "/")


### PR DESCRIPTION
See fx `https://github.com/satori/go.uuid`

Error I see when running `gothanks`:
`Sending a star to github.com/satori/go
Could not star github.com/satori/go PUT https://api.github.com/user/starred/satori/go: 404 Not Found`