### PR TITLE
Fix: Add new line on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 
 			_, err = client.Activity.Star(ctx, rep.owner, rep.repo)
 			if err != nil {
-				fmt.Printf("Could not star %s %s", rep.path, err)
+				fmt.Printf("Could not star %s %s\n", rep.path, err)
 			}
 		}
 	}


### PR DESCRIPTION
See this on errors:
`Could not star github.com/satori/go PUT https://api.github.com/user/starred/satori/go: 404 Not Found []Repository github.com/golang/net is already starred!`

This commit adds the missing new line.