### PR TITLE
Concurrently like all repos at once with goroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v0.3.1] - 2021-01-04
+### Added
+- Concurrently like all repos at once with `goroutine`
+
 ## [v0.3.0] - 2020-04-12
 ### Added
 - Run gothanks using docker


### PR DESCRIPTION
I found that I can improve performance on potentially huge projects by liking all repos at the same time instead of sequentially. Used a separate goroutine for each repo, synced by a WaitGroup.

Some additional thoughts:
- Consider replacing each call to `client.Activity.IsStarred()` with a single initial call to `client.Activity.ListStarred()`.
- Not sure how GitHub API might behave with hundreds of simultaneous requests.

I am quite new to Go and this is my first open source contribution in the language so please let me know if I missed something. Thanks!